### PR TITLE
set the xmlns attribute for outer svg when scaling

### DIFF
--- a/org-latex-impatient.el
+++ b/org-latex-impatient.el
@@ -473,8 +473,7 @@ Showing at point END"
                (not (equal org-latex-impatient-scale 1.0)))
       (setq ss
             (concat
-             ;; 100% seems wierd
-             "<svg height=\"110%\">"
+             "<svg xmlns=\"http://www.w3.org/2000/svg\">"
              ;; ad-hoc for scaling
              (format "<g transform=\"scale(%s)\">" org-latex-impatient-scale)
              ss


### PR DESCRIPTION
Currently, when scaling, we wrap the content of the svg (which is xml) in something that looks like

```xml
<svg height=110%>
<g transform=scale(XX)>
VALID SVG HERE...
</g>
</svg>
```
However, in order to be "valid svg" we need to specify the namespace: `xmlns="http://www.w3.org/svg"`.

I suspect that some svg rendering libraries are a bit forgiving of this, and you are working with a file with an extension that ends in `.svg` it will assume that's the namespace that you mean, but at least for me (`emacs-mac` on `Mac OSX`), things aren't so forgiving.

To my eye, scaling with height set to 110% looked a little weird, and it looked better with 100% scaling, so I also changed that.