### PR TITLE
default to finding tex2svg on user's $PATH

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -10,9 +10,9 @@
 * Installation
   You can install =MathJax-node-cli= via ~npm~:
   #+BEGIN_SRC shell
-npm install mathjax-node-cli
+    npm install -g mathjax-node-cli
   #+END_SRC
-  You need to set ~org-latex-impatient-tex2svg-bin~ to the location of the executable ~tex2svg~.
+  You may need to set ~org-latex-impatient-tex2svg-bin~ to the location of the executable ~tex2svg~.
 
 * Usage
    #+begin_src emacs-lisp

--- a/org-latex-impatient.el
+++ b/org-latex-impatient.el
@@ -41,7 +41,7 @@
 (require 'posframe)
 (require 'org-element)
 
-(defcustom org-latex-impatient-tex2svg-bin ""
+(defcustom org-latex-impatient-tex2svg-bin "tex2svg"
   "Location of tex2svg executable."
   :group 'org-latex-impatient
   :type '(string))


### PR DESCRIPTION
If `tex2svg` is installed in such a way that it is available on `$PATH` (from within emacs), then there's no need for the user to install it manually.

I've set the default value of `org-latex-impatient-tex2svg-bin` to simply `tex2svg` (as opposed to the empty string which it was previously set to); this default will work if emacs can find `tex2svg` on the path. I've also updated the documentation to specify that the user *may* need to set the value (since otherwise things may just work). I've also adjusted the documentation to suggest a global installation of `mathjax-node-cli` (and fixed some indentation while I was at it), since IMHO this makes it more likely that `tex2svg` will be on `$PATH` (e.g., on MacOS, if `node` is installed using `homebrew`, then `npm install -g mathjax-node-cli` will put `tex2svg` under `/opt/homebrew/bin/tex2svg`, which is likely to be on `$PATH`