### PR TITLE
ensure calls to equal-or-member function use org-latex-impatient

### DIFF
--- a/org-latex-impatient.el
+++ b/org-latex-impatient.el
@@ -273,11 +273,11 @@ available in upstream."
            (save-excursion
              (setq begin (prop-match-beginning
                           (text-property--find-end-backward
-                           (point) 'face 'markdown-math-face #'yang/equal-or-member))))
+                           (point) 'face 'markdown-math-face #'org-latex-impatient--equal-or-member))))
            (save-excursion
              (setq end (prop-match-end
                         (text-property--find-end-forward
-                         (point) 'face 'markdown-math-face #'yang/equal-or-member)))
+                         (point) 'face 'markdown-math-face #'org-latex-impatient--equal-or-member)))
              (unless (looking-at (rx (or "$$" "\\]")))
                (setq org-latex-impatient--is-inline t)
                (message "setting is-line to %s" org-latex-impatient--is-inline)))
@@ -301,7 +301,7 @@ available in upstream."
                 (save-excursion
                   (prop-match-end
                    (text-property--find-end-forward
-                    (point) 'face 'markdown-math-face #'yang/equal-or-member))))
+                    (point) 'face 'markdown-math-face #'org-latex-impatient--equal-or-member))))
                (t (message "Only org-mode, latex-mode, and markdown-mode supported") nil)))
         ((eq org-latex-impatient-posframe-position 'point)
          (point))


### PR DESCRIPTION
org-latex-impatient provides a useful function called `org-latex-impatient--equal-or-member`, which it calls in a few places. however, in some places (mostly in code handling markdown mode), it instead calls `yang/equal-or-member`. I assume this is an artifact of the development cycle and that the latter is a function available to the developer, but not in the package. I've simply renamed any instances of `yang/equal-or-member` to `org-latex-impatient--equal-or-member`.